### PR TITLE
serial_test: re-export the `serial` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ version = "0.2.0"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial_test_derive 0.2.0",
 ]
 
 [[package]]
@@ -129,7 +130,6 @@ version = "0.2.0"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.2.0",
- "serial_test_derive 0.2.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# serial_test_derive
-[![Version](https://img.shields.io/crates/v/serial_test_derive.svg)](https://crates.io/crates/serial_test_derive)
-[![Docs](https://docs.rs/serial_test_derive/badge.svg)](https://docs.rs/serial_test_derive/)
-![MIT license](https://img.shields.io/crates/l/serial_test_derive.svg)
+# serial_test
+[![Version](https://img.shields.io/crates/v/serial_test.svg)](https://crates.io/crates/serial_test)
+[![Docs](https://docs.rs/serial_test/badge.svg)](https://docs.rs/serial_test/)
+![MIT license](https://img.shields.io/crates/l/serial_test.svg)
 [![Build Status](https://travis-ci.com/palfrey/serial_test.svg?branch=master)](https://travis-ci.com/palfrey/serial_test)
 
-`serial_test_derive` allows for the creation of serialised Rust tests using the `serial` attribute
+`serial_test` allows for the creation of serialised Rust tests using the `serial` attribute
 e.g.
 ````
 #[test]
@@ -28,13 +28,12 @@ Add to your Cargo.toml
 ```
 [dev-dependencies]
 serial_test = "*"
-serial_test_derive = "*"
 ```
 
-plus `use serial_test_derive::serial;` (for Rust 2018) or
+plus `use serial_test::serial;` (for Rust 2018) or
 ```
 #[macro_use]
-extern crate serial_test_derive;
+extern crate serial_test;
 ```
 for earlier versions.
 

--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -12,3 +12,4 @@ categories = ["development-tools::testing"]
 [dependencies]
 lazy_static = "1.2"
 parking_lot = "0.9"
+serial_test_derive = { version = "~0.2.0", path = "../serial_test_derive" }

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -40,3 +40,8 @@ pub fn serial_core(name: &str, function: fn()) {
     let _guard = unlock.deref()[name].lock();
     function();
 }
+
+// Re-export #[serial].
+#[allow(unused_imports)]
+#[doc(hidden)]
+pub use serial_test_derive::*;

--- a/serial_test_test/Cargo.toml
+++ b/serial_test_test/Cargo.toml
@@ -7,6 +7,5 @@ authors = ["Tom Parker-Shemilt <palfrey@tevp.net>"]
 edition = "2018"
 
 [dev-dependencies]
-serial_test_derive = { path="../serial_test_derive" }
 serial_test = { path="../serial_test" }
 lazy_static = "1.2"

--- a/serial_test_test/src/lib.rs
+++ b/serial_test_test/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use lazy_static::lazy_static;
-    use serial_test_derive::serial;
+    use serial_test::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::thread;


### PR DESCRIPTION
This avoids the need to import two crates. Also update the documentation
to use the `serial_test` crate instead (the docs are still linked to
`serial_test_derive` since that is where the meat of the docs live for
the crate).

Fixes: #3