### PR TITLE
Skip ignore attribute, as it's already parsed out

### DIFF
--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -2,10 +2,10 @@
 //! Helper crate for [serial_test_derive](../serial_test_derive/index.html)
 
 use lazy_static::lazy_static;
+use parking_lot::ReentrantMutex;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, RwLock};
-use parking_lot::ReentrantMutex;
 
 lazy_static! {
     static ref LOCKS: Arc<RwLock<HashMap<String, ReentrantMutex<()>>>> =

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -87,7 +87,22 @@ pub fn serial(attr: TokenStream, input: TokenStream) -> TokenStream {
     let ast: syn::ItemFn = syn::parse(input).unwrap();
     let name = ast.ident;
     let block = ast.block;
-    let attrs = ast.attrs;
+    let attrs: Vec<syn::Attribute> = ast
+        .attrs
+        .into_iter()
+        .filter(|at| {
+            if let Ok(m) = at.parse_meta() {
+                if m.name().to_string() == "ignore" {
+                    // we skip ignore because the test framework already deals with it
+                    false
+                } else {
+                    true
+                }
+            } else {
+                true
+            }
+        })
+        .collect();
     let gen = quote! {
         #(#attrs)
         *

--- a/serial_test_test/src/lib.rs
+++ b/serial_test_test/src/lib.rs
@@ -47,13 +47,14 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_fun() {
+    #[ignore]
+    fn test_ignore_fun() {
         assert_eq!(1 + 2, 3);
     }
 
     #[test]
     #[serial]
     fn test_reentrant_fun() {
-        test_fun();
+        test_ignore_fun();
     }
 }


### PR DESCRIPTION
Fixes #5. There aren't any tests for this really, because the current state of proc macros makes this hard....