### PR TITLE
Remove extra braces around generated serial code to improve coverage

### DIFF
--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -103,18 +103,14 @@ fn serial_core(
                 #(#attrs)
                 *
                 async fn #name () -> #ret {
-                    serial_test::async_serial_core_with_return(#key, || async {
-                        #block
-                    }).await;
+                    serial_test::async_serial_core_with_return(#key, || async #block ).await;
                 }
             },
             None => quote! {
                 #(#attrs)
                 *
                 fn #name () -> #ret {
-                    serial_test::serial_core_with_return(#key, || {
-                        #block
-                    })
+                    serial_test::serial_core_with_return(#key, || #block )
                 }
             },
         }
@@ -124,18 +120,14 @@ fn serial_core(
                 #(#attrs)
                 *
                 async fn #name () {
-                    serial_test::async_serial_core(#key, || async {
-                        #block
-                    }).await;
+                    serial_test::async_serial_core(#key, || async #block ).await;
                 }
             },
             None => quote! {
                 #(#attrs)
                 *
                 fn #name () {
-                    serial_test::serial_core(#key, || {
-                        #block
-                    });
+                    serial_test::serial_core(#key, || #block );
                 }
             },
         }
@@ -153,9 +145,7 @@ fn test_serial() {
     let compare = quote! {
         #[test]
         fn foo () {
-            serial_test::serial_core("", || {
-                {}
-            });
+            serial_test::serial_core("", || {} );
         }
     };
     assert_eq!(format!("{}", compare), format!("{}", stream));
@@ -177,9 +167,7 @@ fn test_stripped_attributes() {
         #[test]
         #[something_else]
         fn foo () {
-            serial_test::serial_core("", || {
-                {}
-            });
+            serial_test::serial_core("", || {} );
         }
     };
     assert_eq!(format!("{}", compare), format!("{}", stream));
@@ -196,9 +184,7 @@ fn test_serial_async() {
     let compare = quote! {
         #[tokio::test]
         async fn foo () {
-            serial_test::async_serial_core("", || async {
-                {}
-            }).await;
+            serial_test::async_serial_core("", || async {} ).await;
         }
     };
     assert_eq!(format!("{}", compare), format!("{}", stream));
@@ -215,9 +201,7 @@ fn test_serial_async_return() {
     let compare = quote! {
         #[tokio::test]
         async fn foo () -> Result<(), ()> {
-            serial_test::async_serial_core_with_return("", || async {
-                { Ok(()) }
-            }).await;
+            serial_test::async_serial_core_with_return("", || async { Ok(()) } ).await;
         }
     };
     assert_eq!(format!("{}", compare), format!("{}", stream));


### PR DESCRIPTION
Implementing #37 