### PR TITLE
Permit beta/nightly clippy fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           RUSTFLAGS: -Dwarnings
         with:
           command: clippy
+        continue-on-error: ${{ matrix.rust == 'nightly' || matrix.rust == 'beta' }}
       - name: Build and test
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints)]
+#![allow(must_not_suspend)]
 //! # serial_test
 //! `serial_test` allows for the creation of serialised Rust tests using the [serial](attr.serial.html) attribute
 //! e.g.

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints)]
-#![allow(must_not_suspend)]
 //! # serial_test
 //! `serial_test` allows for the creation of serialised Rust tests using the [serial](attr.serial.html) attribute
 //! e.g.


### PR DESCRIPTION
Mostly because of https://github.com/rust-lang/rust/issues/83310 but generally also useful