### PR TITLE
Fix race condition in check_new_key

### DIFF
--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -21,7 +21,8 @@ fn check_new_key(name: &str) {
             .write()
             .unwrap()
             .deref_mut()
-            .insert(name.to_string(), ReentrantMutex::new(()));
+            .entry(name.to_string())
+            .or_default();
     }
 }
 


### PR DESCRIPTION
Fix a race condition where one thread could replace the inner `ReentrantMutex` with another one.

This can happen if two threads call `check_new_key` at the same time, both check for the key and don't find it and then the first one to get the write lock will insert a new `ReentrantMutex` under that key, but once the second thread gets the write lock, it will replace that `ReentrantMutex` with a different one.