### PR TITLE
Make logging with log a default feature

### DIFF
--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -16,7 +16,7 @@ parking_lot = "^0.12"
 serial_test_derive = { version = "~0.7.0", path = "../serial_test_derive" }
 fslock = {version = "0.2", optional = true}
 document-features = {version = "0.2", optional=true}
-log = "0.4"
+log = {version = "0.4", optional = true}
 futures = {version = "^0.3", default_features = false, features = ["executor"] }
 
 [dev-dependencies]
@@ -24,7 +24,9 @@ itertools = "0.10"
 tokio = { version = "^1.17", features = ["macros", "rt"] }
 
 [features]
-default = []
+default = ["logging"]
+
+logging = ["log"]
 
 ## The file_locks feature unlocks the `file_serial` macro
 file_locks = ["fslock"]

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -1,5 +1,6 @@
 use crate::rwlock::{Locks, MutexGuardWrapper};
 use lazy_static::lazy_static;
+#[cfg(feature = "logging")]
 use log::debug;
 use parking_lot::{Mutex, RwLock};
 use std::{
@@ -78,6 +79,7 @@ pub(crate) fn check_new_key(name: &str) {
     let start = Instant::now();
     loop {
         let duration = Instant::now() - start;
+        #[cfg(feature = "logging")]
         debug!("Waiting for '{}' {:?}", name, duration);
         // Check if a new key is needed. Just need a read lock, which can be done in sync with everyone else
         let try_unlock = LOCKS.try_read_recursive_for(Duration::from_secs(1));


### PR DESCRIPTION
This change makes logging with the `log` crate a (default) feature but otherwise allows it, and the crate dependency, to be opted-out of by upstream consumers.

