### PR TITLE
serial_test_test now switches off defaults for serial_test

### DIFF
--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -78,9 +78,11 @@ pub(crate) fn wait_duration() -> Duration {
 pub(crate) fn check_new_key(name: &str) {
     let start = Instant::now();
     loop {
-        let duration = Instant::now() - start;
         #[cfg(feature = "logging")]
-        debug!("Waiting for '{}' {:?}", name, duration);
+        {
+            let duration = Instant::now() - start;
+            debug!("Waiting for '{}' {:?}", name, duration);
+        }
         // Check if a new key is needed. Just need a read lock, which can be done in sync with everyone else
         let try_unlock = LOCKS.try_read_recursive_for(Duration::from_secs(1));
         if let Some(unlock) = try_unlock {

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![deny(unused_variables)]
 
 //! # serial_test
 //! `serial_test` allows for the creation of serialised Rust tests using the [serial](macro@serial) attribute

--- a/serial_test_test/Cargo.toml
+++ b/serial_test_test/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Tom Parker-Shemilt <palfrey@tevp.net>"]
 edition = "2018"
 
 [dependencies]
-serial_test = { path="../serial_test" }
+serial_test = { path="../serial_test", default_features = false }
 lazy_static = "^1.2"
 env_logger = "^0.9"
 parking_lot = "^0.12"
@@ -18,5 +18,5 @@ actix-rt = { version = "^2.7", features = ["macros"] }
 futures-util = {version = "^0.3", default_features = false }
 
 [features]
-default = []
+default = ["serial_test/logging"]
 file_locks = ["serial_test/file_locks"]


### PR DESCRIPTION
Following up on #63 not doing quite what I wanted it to, and supporting testing for #62