### PR TITLE
Various tidyups for file lock

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.'cfg(feature = "cargo-clippy")']
+rustflags = [
+  "-Dclippy::print_stdout",
+  "-Dclippy::print_stderr",
+  "-Dclippy::dbg_macro",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.jpg
 .DS_Store
+.vscode/

--- a/serial_test/src/file_lock.rs
+++ b/serial_test/src/file_lock.rs
@@ -1,4 +1,6 @@
 use fslock::LockFile;
+#[cfg(feature = "logging")]
+use log::debug;
 use std::{env, fs, path::Path};
 
 struct Lock {
@@ -8,7 +10,8 @@ struct Lock {
 impl Lock {
     fn unlock(self: &mut Lock) {
         self.lockfile.unlock().unwrap();
-        println!("Unlock");
+        #[cfg(feature = "logging")]
+        debug!("Unlock");
     }
 }
 
@@ -17,9 +20,11 @@ fn do_lock(path: &str) -> Lock {
         fs::write(path, "").unwrap_or_else(|_| panic!("Lock file path was {:?}", path))
     }
     let mut lockfile = LockFile::open(path).unwrap();
-    println!("Waiting on {:?}", path);
+    #[cfg(feature = "logging")]
+    debug!("Waiting on {:?}", path);
     lockfile.lock().unwrap();
-    println!("Locked for {:?}", path);
+    #[cfg(feature = "logging")]
+    debug!("Locked for {:?}", path);
     Lock { lockfile }
 }
 

--- a/serial_test/src/serial_code_lock.rs
+++ b/serial_test/src/serial_code_lock.rs
@@ -50,6 +50,7 @@ pub async fn local_async_serial_core(name: &str, fut: impl std::future::Future<O
 }
 
 #[cfg(test)]
+#[allow(clippy::print_stdout)]
 mod tests {
     use super::local_serial_core;
     use crate::code_lock::{check_new_key, wait_duration, LOCKS};

--- a/serial_test_test/src/lib.rs
+++ b/serial_test_test/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stdout)] // because test code
+
 //! Not inside the cfg(test) block because of <https://github.com/rust-lang/rust/issues/45599>
 //! ```
 //! #[macro_use] extern crate serial_test;


### PR DESCRIPTION
* Remove and explicitly lint-out left over `println`'s
* Add a "assert in middle of test" test for file lock (which just works because [fslock implemented Drop](https://docs.rs/fslock/latest/fslock/struct.LockFile.html#impl-Drop))