### PR TITLE
Move rustversion declaration to a dev-dependency

### DIFF
--- a/serial_test_derive/Cargo.toml
+++ b/serial_test_derive/Cargo.toml
@@ -17,8 +17,8 @@ quote = "1.0"
 syn = { version="1.0", features=["full"] }
 proc-macro2 = "1.0"
 proc-macro-error = { version = "1" }
-rustversion = "1.0"
 
 [dev-dependencies]
 env_logger = "0.9"
+rustversion = "1.0"
 trybuild = "1"


### PR DESCRIPTION
This PR moves the use of `rustversion` in the Cargo.toml to the `dev-dependency` section instead of the regular dependencies. 

This crate is only used in tests, so its the correct location for it. Otherwise, downstream consumers will have it put in their `Cargo.lock` files for no reason other than to build it.