### PR TITLE
Per test timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ extern crate serial_test;
 for earlier versions.
 
 You can then either add `#[serial]` or `#[serial(some_text)]` to tests as required.
+
+For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
+the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
+lead to some unpredictable behavior based on the number of parallel tests run on the system.
+```rust
+#[test]
+#[serial(timeout_ms = 1000)]
+fn test_serial_one() {
+  // Do things
+}
+#[test]
+#[serial(test_name, timeout_ms = 1000)]
+fn test_serial_another() {
+  // Do things
+}
+```

--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -27,17 +27,13 @@ itertools = "0.10"
 tokio = { version = "^1.17", features = ["macros", "rt"] }
 
 [features]
-default = ["logging", "timeout"]
+default = ["logging"]
 
 ## Switches on debug logging (and requires the `log` package)
 logging = ["log"]
 
 ## The file_locks feature unlocks the `file_serial`/`file_parallel` macros
 file_locks = ["fslock"]
-
-## The `timeout` feature lets tests time out after a certain amount of time
-## if not enabled tests will wait indefinitely to be started
-timeout = []
 
 docsrs = ["document-features"]
 

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -3,9 +3,10 @@ use dashmap::{try_result::TryResult, DashMap};
 use lazy_static::lazy_static;
 #[cfg(all(feature = "logging"))]
 use log::debug;
-use std::sync::{atomic::AtomicU32, Arc};
-use std::time::Duration;
-use std::time::Instant;
+use std::{
+    sync::{atomic::AtomicU32, Arc},
+    time::{Duration, Instant},
+};
 
 pub(crate) struct UniqueReentrantMutex {
     locks: Locks,

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -1,13 +1,10 @@
 use crate::rwlock::{Locks, MutexGuardWrapper};
 use dashmap::{try_result::TryResult, DashMap};
 use lazy_static::lazy_static;
-#[cfg(all(feature = "logging", feature = "timeout"))]
+#[cfg(all(feature = "logging"))]
 use log::debug;
-#[cfg(feature = "timeout")]
 use std::sync::{atomic::AtomicU32, Arc};
-#[cfg(feature = "timeout")]
 use std::time::Duration;
-#[cfg(feature = "timeout")]
 use std::time::Instant;
 
 pub(crate) struct UniqueReentrantMutex {
@@ -60,7 +57,7 @@ impl Default for UniqueReentrantMutex {
 pub(crate) fn check_new_key(name: &str, max_wait: Option<Duration>) {
     let start = Instant::now();
     loop {
-        #[cfg(all(feature = "logging", feature = "timeout"))]
+        #[cfg(all(feature = "logging"))]
         {
             let duration = start.elapsed();
             debug!("Waiting for '{}' {:?}", name, duration);
@@ -87,7 +84,6 @@ pub(crate) fn check_new_key(name: &str, max_wait: Option<Duration>) {
         // If the try_entry fails, then go around the loop again
         // Odds are another test was also locking on the write and has now written the key
 
-        #[cfg(feature = "timeout")]
         if let Some(max_wait) = max_wait {
             let duration = start.elapsed();
             if duration > max_wait {

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -64,8 +64,6 @@ mod parallel_file_lock;
 #[cfg(feature = "file_locks")]
 mod serial_file_lock;
 
-#[cfg(feature = "timeout")]
-pub use code_lock::set_max_wait;
 pub use parallel_code_lock::{
     local_async_parallel_core, local_async_parallel_core_with_return, local_parallel_core,
     local_parallel_core_with_return,

--- a/serial_test/src/parallel_code_lock.rs
+++ b/serial_test/src/parallel_code_lock.rs
@@ -2,14 +2,15 @@
 
 use crate::code_lock::{check_new_key, LOCKS};
 use futures::FutureExt;
-use std::panic;
+use std::{panic, time::Duration};
 
 #[doc(hidden)]
 pub fn local_parallel_core_with_return<E>(
     name: &str,
+    max_wait: Option<Duration>,
     function: fn() -> Result<(), E>,
 ) -> Result<(), E> {
-    check_new_key(name);
+    check_new_key(name, max_wait);
 
     let lock = LOCKS.get(name).unwrap();
     lock.start_parallel();
@@ -24,8 +25,8 @@ pub fn local_parallel_core_with_return<E>(
 }
 
 #[doc(hidden)]
-pub fn local_parallel_core(name: &str, function: fn()) {
-    check_new_key(name);
+pub fn local_parallel_core(name: &str, max_wait: Option<Duration>, function: fn()) {
+    check_new_key(name, max_wait);
 
     let lock = LOCKS.get(name).unwrap();
     lock.start_parallel();
@@ -41,9 +42,10 @@ pub fn local_parallel_core(name: &str, function: fn()) {
 #[doc(hidden)]
 pub async fn local_async_parallel_core_with_return<E>(
     name: &str,
+    max_wait: Option<Duration>,
     fut: impl std::future::Future<Output = Result<(), E>> + panic::UnwindSafe,
 ) -> Result<(), E> {
-    check_new_key(name);
+    check_new_key(name, max_wait);
 
     let lock = LOCKS.get(name).unwrap();
     lock.start_parallel();
@@ -60,9 +62,10 @@ pub async fn local_async_parallel_core_with_return<E>(
 #[doc(hidden)]
 pub async fn local_async_parallel_core(
     name: &str,
+    max_wait: Option<Duration>,
     fut: impl std::future::Future<Output = ()> + panic::UnwindSafe,
 ) {
-    check_new_key(name);
+    check_new_key(name, max_wait);
 
     let lock = LOCKS.get(name).unwrap();
     lock.start_parallel();
@@ -84,7 +87,7 @@ mod tests {
     #[test]
     fn unlock_on_assert_sync_without_return() {
         let _ = panic::catch_unwind(|| {
-            local_parallel_core("unlock_on_assert_sync_without_return", || {
+            local_parallel_core("unlock_on_assert_sync_without_return", None, || {
                 assert!(false);
             })
         });
@@ -102,6 +105,7 @@ mod tests {
         let _ = panic::catch_unwind(|| {
             local_parallel_core_with_return(
                 "unlock_on_assert_sync_with_return",
+                None,
                 || -> Result<(), Error> {
                     assert!(false);
                     Ok(())
@@ -123,7 +127,8 @@ mod tests {
             assert!(false);
         }
         async fn call_serial_test_fn() {
-            local_async_parallel_core("unlock_on_assert_async_without_return", demo_assert()).await
+            local_async_parallel_core("unlock_on_assert_async_without_return", None, demo_assert())
+                .await
         }
         // as per https://stackoverflow.com/a/66529014/320546
         let _ = panic::catch_unwind(|| {
@@ -151,6 +156,7 @@ mod tests {
         async fn call_serial_test_fn() {
             local_async_parallel_core_with_return(
                 "unlock_on_assert_async_with_return",
+                None,
                 demo_assert(),
             )
             .await;

--- a/serial_test/src/serial_file_lock.rs
+++ b/serial_test/src/serial_file_lock.rs
@@ -1,7 +1,9 @@
+use std::time::Duration;
+
 use crate::file_lock::make_lock_for_name_and_path;
 
 #[doc(hidden)]
-pub fn fs_serial_core(name: &str, path: Option<&str>, function: fn()) {
+pub fn fs_serial_core(name: &str, _max_wait: Option<Duration>, path: Option<&str>, function: fn()) {
     let mut lock = make_lock_for_name_and_path(name, path);
     lock.start_serial();
     function();
@@ -11,6 +13,7 @@ pub fn fs_serial_core(name: &str, path: Option<&str>, function: fn()) {
 #[doc(hidden)]
 pub fn fs_serial_core_with_return<E>(
     name: &str,
+    _max_wait: Option<Duration>,
     path: Option<&str>,
     function: fn() -> Result<(), E>,
 ) -> Result<(), E> {
@@ -24,6 +27,7 @@ pub fn fs_serial_core_with_return<E>(
 #[doc(hidden)]
 pub async fn fs_async_serial_core_with_return<E>(
     name: &str,
+    _max_wait: Option<Duration>,
     path: Option<&str>,
     fut: impl std::future::Future<Output = Result<(), E>>,
 ) -> Result<(), E> {
@@ -37,6 +41,7 @@ pub async fn fs_async_serial_core_with_return<E>(
 #[doc(hidden)]
 pub async fn fs_async_serial_core(
     name: &str,
+    _max_wait: Option<Duration>,
     path: Option<&str>,
     fut: impl std::future::Future<Output = ()>,
 ) {
@@ -57,14 +62,14 @@ mod tests {
 
     #[test]
     fn test_serial() {
-        fs_serial_core("test", None, || {});
+        fs_serial_core("test", None, None, || {});
     }
 
     #[test]
     fn unlock_on_assert_sync_without_return() {
         let lock_path = path_for_name("unlock_on_assert_sync_without_return");
         let _ = panic::catch_unwind(|| {
-            fs_serial_core("foo", Some(&lock_path), || {
+            fs_serial_core("foo", None, Some(&lock_path), || {
                 assert!(false);
             })
         });

--- a/serial_test/tests/tests.rs
+++ b/serial_test/tests/tests.rs
@@ -2,7 +2,7 @@ use serial_test::local_serial_core;
 
 #[test]
 fn test_empty_serial_call() {
-    local_serial_core("beta", || {
+    local_serial_core("beta", None, || {
         println!("Bar");
     });
 }

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -33,6 +33,7 @@ use std::ops::Deref;
 /// If you want different subsets of tests to be serialised with each
 /// other, but not depend on other subsets, you can add an argument to [serial](macro@serial), and all calls
 /// with identical arguments will be called in serial. e.g.
+///
 /// ````
 /// #[test]
 /// #[serial(something)]
@@ -60,6 +61,24 @@ use std::ops::Deref;
 /// ````
 /// `test_serial_one` and `test_serial_another` will be executed in serial, as will `test_serial_third` and `test_serial_fourth`
 /// but neither sequence will be blocked by the other
+///
+/// For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
+/// the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
+/// lead to some unpredictable behavior based on the number of parallel tests run on the system.
+///
+/// ````
+/// #[test]
+/// #[serial(timeout_ms = 1000)]
+/// fn test_serial_one() {
+///   // Do things
+/// }
+///
+/// #[test]
+/// #[serial(timeout_ms = 1000)]
+/// fn test_serial_another() {
+///   // Do things
+/// }
+/// ````
 ///
 /// Nested serialised tests (i.e. a [serial](macro@serial) tagged test calling another) are supported
 #[proc_macro_attribute]

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -309,6 +309,9 @@ fn local_parallel_core(
 
 fn fs_args(attr: proc_macro2::TokenStream) -> Vec<Box<dyn ToTokens>> {
     let config = get_core_key(attr);
+    if config.timeout.is_some() {
+        panic!("Timeout is not supported for file_serial");
+    }
     vec![
         Box::new(config.name),
         Box::new(QuoteOption(config.timeout)),

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -213,7 +213,7 @@ fn get_raw_args(attr: proc_macro2::TokenStream) -> Vec<Arg> {
         match attrs.remove(0) {
             TokenTree::Ident(id) => {
                 let name = id.to_string();
-                if name == "timeout" {
+                if name == "timeout_ms" {
                     match attrs.first() {
                         Some(TokenTree::Punct(p)) if p.as_char() == '=' && !attrs.is_empty() => {
                             attrs.remove(0);

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -476,6 +476,55 @@ mod tests {
     }
 
     #[test]
+    fn test_serial_with_timeout() {
+        let attrs = vec![
+            TokenTree::Ident(format_ident!("timeout_ms")),
+            TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+            TokenTree::Literal(Literal::u8_unsuffixed(42)),
+        ];
+        let input = quote! {
+            #[test]
+            fn foo() {}
+        };
+        let stream = local_serial_core(
+            proc_macro2::TokenStream::from_iter(attrs.into_iter()),
+            input,
+        );
+        let compare = quote! {
+            #[test]
+            fn foo () {
+                serial_test::local_serial_core("",  :: std :: option :: Option :: Some (42u64), || {} );
+            }
+        };
+        assert_eq!(format!("{}", compare), format!("{}", stream));
+    }
+
+    #[test]
+    fn test_serial_with_name_and_timeout() {
+        let attrs = vec![
+            TokenTree::Ident(format_ident!("foo")),
+            TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+            TokenTree::Ident(format_ident!("timeout_ms")),
+            TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+            TokenTree::Literal(Literal::u8_unsuffixed(42)),
+        ];
+        let input = quote! {
+            #[test]
+            fn foo() {}
+        };
+        let stream = local_serial_core(
+            proc_macro2::TokenStream::from_iter(attrs.into_iter()),
+            input,
+        );
+        let compare = quote! {
+            #[test]
+            fn foo () {
+                serial_test::local_serial_core("foo",  :: std :: option :: Option :: Some (42u64), || {} );
+            }
+        };
+        assert_eq!(format!("{}", compare), format!("{}", stream));
+    }
+    #[test]
     fn test_stripped_attributes() {
         let _ = env_logger::builder().is_test(true).try_init();
         let attrs = proc_macro2::TokenStream::new();

--- a/serial_test_test/src/lib.rs
+++ b/serial_test_test/src/lib.rs
@@ -107,6 +107,14 @@ mod tests {
     use serial_test::{file_parallel, file_serial};
 
     #[test]
+    #[serial(timeout_key, timeout_ms = 60000)]
+    fn demo_timeout_with_key() {}
+
+    #[test]
+    #[serial(timeout_ms = 60000)]
+    fn demo_timeout() {}
+
+    #[test]
     #[serial]
     fn test_serial_no_arg() {
         init();

--- a/serial_test_test/src/lib.rs
+++ b/serial_test_test/src/lib.rs
@@ -107,11 +107,12 @@ mod tests {
     use serial_test::{file_parallel, file_serial};
 
     #[test]
-    #[serial(timeout_key, timeout_ms = 60000)]
+    #[serial()]
     fn demo_timeout_with_key() {}
 
     #[test]
-    #[serial(timeout_ms = 60000)]
+    #[serial()]
+    // #[serial(timeout_ms = 60000)]
     fn demo_timeout() {}
 
     #[test]

--- a/serial_test_test/src/lib.rs
+++ b/serial_test_test/src/lib.rs
@@ -107,12 +107,11 @@ mod tests {
     use serial_test::{file_parallel, file_serial};
 
     #[test]
-    #[serial()]
+    #[serial(timeout_key, timeout_ms = 60000)]
     fn demo_timeout_with_key() {}
 
     #[test]
-    #[serial()]
-    // #[serial(timeout_ms = 60000)]
+    #[serial(timeout_ms = 60000)]
     fn demo_timeout() {}
 
     #[test]


### PR DESCRIPTION
So this is still a draft, it adds the option to define a timeout as part of the serial test something along the lines of:

```rust
#[test]
#[serial(timeout = 600)]
fn test() -> {}
```

I've not added tests or documentation yet as I wanted to get feedback on if this approach is OK before putting in that work :)