### PR TITLE
Redo locks with dashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "dashmap"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
+ "parking_lot",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +289,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +460,7 @@ dependencies = [
 name = "serial_test"
 version = "0.8.0"
 dependencies = [
+ "dashmap",
  "document-features",
  "fslock",
  "futures",

--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -20,6 +20,7 @@ log = { version = "0.4", optional = true }
 futures = { version = "^0.3", default_features = false, features = [
     "executor",
 ] }
+dashmap = { version = "5"}
 
 [dev-dependencies]
 itertools = "0.10"

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -3,13 +3,13 @@ use dashmap::{try_result::TryResult, DashMap};
 use lazy_static::lazy_static;
 #[cfg(feature = "logging")]
 use log::debug;
+#[cfg(feature = "timeout")]
 use parking_lot::RwLock;
+use std::sync::{atomic::AtomicU32, Arc};
+#[cfg(feature = "timeout")]
+use std::time::Duration;
 #[cfg(feature = "timeout")]
 use std::time::Instant;
-use std::{
-    sync::{atomic::AtomicU32, Arc},
-    time::Duration,
-};
 
 pub(crate) struct UniqueReentrantMutex {
     locks: Locks,

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -1,4 +1,5 @@
 use crate::rwlock::{Locks, MutexGuardWrapper};
+use dashmap::{try_result::TryResult, DashMap};
 use lazy_static::lazy_static;
 #[cfg(feature = "logging")]
 use log::debug;
@@ -6,8 +7,6 @@ use parking_lot::RwLock;
 #[cfg(feature = "timeout")]
 use std::time::Instant;
 use std::{
-    collections::HashMap,
-    ops::{Deref, DerefMut},
     sync::{atomic::AtomicU32, Arc},
     time::Duration,
 };
@@ -45,14 +44,14 @@ impl UniqueReentrantMutex {
 }
 
 lazy_static! {
-    pub(crate) static ref LOCKS: Arc<RwLock<HashMap<String, UniqueReentrantMutex>>> =
-        Arc::new(RwLock::new(HashMap::new()));
+    pub(crate) static ref LOCKS: Arc<DashMap<String, UniqueReentrantMutex>> =
+        Arc::new(DashMap::new());
     static ref MUTEX_ID: Arc<AtomicU32> = Arc::new(AtomicU32::new(1));
 }
 
 #[cfg(feature = "timeout")]
 lazy_static! {
-    static ref MAX_WAIT: Arc<RwLock<Duration>> = Arc::new(RwLock::new(Duration::from_secs(60)));
+    static ref MAX_WAIT: Arc<RwLock<Duration>> = Arc::new(RwLock::new(Duration::from_secs(10)));
 }
 
 impl Default for UniqueReentrantMutex {
@@ -93,25 +92,25 @@ pub(crate) fn check_new_key(name: &str) {
             debug!("Waiting for '{}' {:?}", name, duration);
         }
         // Check if a new key is needed. Just need a read lock, which can be done in sync with everyone else
-        let try_unlock = LOCKS.try_read_recursive_for(Duration::from_secs(1));
-        if let Some(unlock) = try_unlock {
-            if unlock.deref().contains_key(name) {
+        match LOCKS.try_get(name) {
+            TryResult::Present(_) => {
                 return;
             }
-            drop(unlock); // so that we don't hold the read lock and so the writer can maybe succeed
-        } else {
-            continue; // wasn't able to get read lock
-        }
+            TryResult::Locked => {
+                continue; // wasn't able to get read lock
+            }
+            TryResult::Absent => {} // do the write path below
+        };
 
         // This is the rare path, which avoids the multi-writer situation mostly
-        let try_lock = LOCKS.try_write_for(Duration::from_secs(1));
+        let try_entry = LOCKS.try_entry(name.to_string());
 
-        if let Some(mut lock) = try_lock {
-            lock.deref_mut().entry(name.to_string()).or_default();
+        if let Some(entry) = try_entry {
+            entry.or_default();
             return;
         }
 
-        // If the try_lock fails, then go around the loop again
+        // If the try_entry fails, then go around the loop again
         // Odds are another test was also locking on the write and has now written the key
 
         #[cfg(feature = "timeout")]

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -51,7 +51,7 @@ lazy_static! {
 
 #[cfg(feature = "timeout")]
 lazy_static! {
-    static ref MAX_WAIT: Arc<RwLock<Duration>> = Arc::new(RwLock::new(Duration::from_secs(10)));
+    static ref MAX_WAIT: Arc<RwLock<Duration>> = Arc::new(RwLock::new(Duration::from_secs(60)));
 }
 
 impl Default for UniqueReentrantMutex {

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(unused_variables)]
 #![deny(missing_docs)]
+#![deny(unused_imports)]
 
 //! # serial_test
 //! `serial_test` allows for the creation of serialised Rust tests using the [serial](macro@serial) attribute


### PR DESCRIPTION
Attempting to solve a problem spotted in https://github.com/palfrey/serial_test/pull/71. Mainly, that if there's any thread trying to add a new key into `LOCKS`, it'll fail while there's another one doing reads. [dashmap](https://docs.rs/dashmap/latest/dashmap/) gives us proper concurrent access, especially given we don't add a new entry to the hashmap once we've added the first lock, which I _think_ solves this.