### PR TITLE
Various docs fixes prior to 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,11 @@ You can then either add `#[serial]` or `#[serial(some_text)]` to tests as requir
 
 For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
 the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
-lead to some unpredictable behavior based on the number of parallel tests run on the system.
+lead to [some unpredictable behavior](https://github.com/palfrey/serial_test/issues/76) based on the number of parallel tests run on the system.
 ```rust
 #[test]
 #[serial(timeout_ms = 1000)]
 fn test_serial_one() {
-  // Do things
-}
-#[test]
-#[serial(test_name, timeout_ms = 1000)]
-fn test_serial_another() {
   // Do things
 }
 ```

--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -32,10 +32,10 @@ default = ["logging", "async"]
 ## Switches on debug logging (and requires the `log` package)
 logging = ["log"]
 
-## Enables async features
+## Enables async features (and requires the `futures` package)
 async = ["futures"]
 
-## The file_locks feature unlocks the `file_serial`/`file_parallel` macros
+## The file_locks feature unlocks the `file_serial`/`file_parallel` macros (and requires the `fslock` package)
 file_locks = ["fslock"]
 
 docsrs = ["document-features"]

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -45,6 +45,18 @@
 //!   // Do things
 //! }
 //! ````
+//! 
+//! 
+//! For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
+//! the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
+//! lead to [some unpredictable behavior](https://github.com/palfrey/serial_test/issues/76) based on the number of parallel tests run on the system.
+//! ```rust
+//! #[test]
+//! #[serial(timeout_ms = 1000)]
+//! fn test_serial_one() {
+//!   // Do things
+//! }
+//! ```
 //!
 //! ## Feature flags
 #![cfg_attr(

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -45,8 +45,8 @@
 //!   // Do things
 //! }
 //! ````
-//! 
-//! 
+//!
+//!
 //! For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
 //! the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
 //! lead to [some unpredictable behavior](https://github.com/palfrey/serial_test/issues/76) based on the number of parallel tests run on the system.

--- a/serial_test_derive/src/lib.rs
+++ b/serial_test_derive/src/lib.rs
@@ -64,18 +64,12 @@ use std::ops::Deref;
 ///
 /// For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
 /// the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
-/// lead to some unpredictable behavior based on the number of parallel tests run on the system.
+/// lead to [some unpredictable behavior](https://github.com/palfrey/serial_test/issues/76) based on the number of parallel tests run on the system.
 ///
 /// ````
 /// #[test]
 /// #[serial(timeout_ms = 1000)]
 /// fn test_serial_one() {
-///   // Do things
-/// }
-///
-/// #[test]
-/// #[serial(timeout_ms = 1000)]
-/// fn test_serial_another() {
 ///   // Do things
 /// }
 /// ````


### PR DESCRIPTION
More clearly specifying the packages required for all the features, and unifying some of the timeout docs