### PR TITLE
Remove timeout_ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,3 @@ extern crate serial_test;
 for earlier versions.
 
 You can then either add `#[serial]` or `#[serial(some_text)]` to tests as required.
-
-For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
-the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
-lead to [some unpredictable behavior](https://github.com/palfrey/serial_test/issues/76) based on the number of parallel tests run on the system.
-```rust
-#[test]
-#[serial(timeout_ms = 1000)]
-fn test_serial_one() {
-  // Do things
-}
-```

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use log::debug;
 use std::{
     sync::{atomic::AtomicU32, Arc},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 pub(crate) struct UniqueReentrantMutex {
@@ -55,7 +55,7 @@ impl Default for UniqueReentrantMutex {
     }
 }
 
-pub(crate) fn check_new_key(name: &str, max_wait: Option<Duration>) {
+pub(crate) fn check_new_key(name: &str) {
     let start = Instant::now();
     loop {
         #[cfg(all(feature = "logging"))]
@@ -84,12 +84,5 @@ pub(crate) fn check_new_key(name: &str, max_wait: Option<Duration>) {
 
         // If the try_entry fails, then go around the loop again
         // Odds are another test was also locking on the write and has now written the key
-
-        if let Some(max_wait) = max_wait {
-            let duration = start.elapsed();
-            if duration > max_wait {
-                panic!("Timeout waiting for '{}' {:?}", name, duration);
-            }
-        }
     }
 }

--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -1,12 +1,11 @@
 use crate::rwlock::{Locks, MutexGuardWrapper};
 use dashmap::{try_result::TryResult, DashMap};
 use lazy_static::lazy_static;
-#[cfg(all(feature = "logging"))]
+#[cfg(feature = "logging")]
 use log::debug;
-use std::{
-    sync::{atomic::AtomicU32, Arc},
-    time::Instant,
-};
+use std::sync::{atomic::AtomicU32, Arc};
+#[cfg(feature = "logging")]
+use std::time::Instant;
 
 pub(crate) struct UniqueReentrantMutex {
     locks: Locks,
@@ -56,9 +55,10 @@ impl Default for UniqueReentrantMutex {
 }
 
 pub(crate) fn check_new_key(name: &str) {
+    #[cfg(feature = "logging")]
     let start = Instant::now();
     loop {
-        #[cfg(all(feature = "logging"))]
+        #[cfg(feature = "logging")]
         {
             let duration = start.elapsed();
             debug!("Waiting for '{}' {:?}", name, duration);

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -46,18 +46,6 @@
 //! }
 //! ````
 //!
-//!
-//! For each test, a timeout can be specified with the `timeout_ms` parameter to the [serial](macro@serial) attribute. Note that
-//! the timeout is counted from the first invocation of the test, not from the time the previous test was completed. This can
-//! lead to [some unpredictable behavior](https://github.com/palfrey/serial_test/issues/76) based on the number of parallel tests run on the system.
-//! ```rust
-//! #[test]
-//! #[serial(timeout_ms = 1000)]
-//! fn test_serial_one() {
-//!   // Do things
-//! }
-//! ```
-//!
 //! ## Feature flags
 #![cfg_attr(
     feature = "docsrs",

--- a/serial_test/src/parallel_file_lock.rs
+++ b/serial_test/src/parallel_file_lock.rs
@@ -1,4 +1,4 @@
-use std::{panic, time::Duration};
+use std::panic;
 
 #[cfg(feature = "async")]
 use futures::FutureExt;
@@ -6,12 +6,7 @@ use futures::FutureExt;
 use crate::file_lock::make_lock_for_name_and_path;
 
 #[doc(hidden)]
-pub fn fs_parallel_core(
-    name: &str,
-    _max_wait: Option<Duration>,
-    path: Option<&str>,
-    function: fn(),
-) {
+pub fn fs_parallel_core(name: &str, path: Option<&str>, function: fn()) {
     make_lock_for_name_and_path(name, path).start_parallel();
     let res = panic::catch_unwind(|| {
         function();
@@ -25,7 +20,6 @@ pub fn fs_parallel_core(
 #[doc(hidden)]
 pub fn fs_parallel_core_with_return<E>(
     name: &str,
-    _max_wait: Option<Duration>,
     path: Option<&str>,
     function: fn() -> Result<(), E>,
 ) -> Result<(), E> {
@@ -44,7 +38,6 @@ pub fn fs_parallel_core_with_return<E>(
 #[cfg(feature = "async")]
 pub async fn fs_async_parallel_core_with_return<E>(
     name: &str,
-    _max_wait: Option<Duration>,
     path: Option<&str>,
     fut: impl std::future::Future<Output = Result<(), E>> + panic::UnwindSafe,
 ) -> Result<(), E> {
@@ -63,7 +56,6 @@ pub async fn fs_async_parallel_core_with_return<E>(
 #[cfg(feature = "async")]
 pub async fn fs_async_parallel_core(
     name: &str,
-    _max_wait: Option<Duration>,
     path: Option<&str>,
     fut: impl std::future::Future<Output = ()> + panic::UnwindSafe,
 ) {
@@ -97,7 +89,6 @@ mod tests {
         let _ = panic::catch_unwind(|| {
             fs_parallel_core(
                 "unlock_on_assert_sync_without_return",
-                None,
                 Some(&lock_path),
                 || {
                     assert!(false);
@@ -113,7 +104,6 @@ mod tests {
         let _ = panic::catch_unwind(|| {
             fs_parallel_core_with_return(
                 "unlock_on_assert_sync_with_return",
-                None,
                 Some(&lock_path),
                 || -> Result<(), Error> {
                     assert!(false);
@@ -134,7 +124,6 @@ mod tests {
         async fn call_serial_test_fn(lock_path: &str) {
             fs_async_parallel_core(
                 "unlock_on_assert_async_without_return",
-                None,
                 Some(&lock_path),
                 demo_assert(),
             )
@@ -164,7 +153,6 @@ mod tests {
         async fn call_serial_test_fn(lock_path: &str) {
             fs_async_parallel_core_with_return(
                 "unlock_on_assert_async_with_return",
-                None,
                 Some(&lock_path),
                 demo_assert(),
             )

--- a/serial_test/src/serial_file_lock.rs
+++ b/serial_test/src/serial_file_lock.rs
@@ -1,9 +1,7 @@
-use std::time::Duration;
-
 use crate::file_lock::make_lock_for_name_and_path;
 
 #[doc(hidden)]
-pub fn fs_serial_core(name: &str, _max_wait: Option<Duration>, path: Option<&str>, function: fn()) {
+pub fn fs_serial_core(name: &str, path: Option<&str>, function: fn()) {
     let mut lock = make_lock_for_name_and_path(name, path);
     lock.start_serial();
     function();
@@ -13,7 +11,6 @@ pub fn fs_serial_core(name: &str, _max_wait: Option<Duration>, path: Option<&str
 #[doc(hidden)]
 pub fn fs_serial_core_with_return<E>(
     name: &str,
-    _max_wait: Option<Duration>,
     path: Option<&str>,
     function: fn() -> Result<(), E>,
 ) -> Result<(), E> {
@@ -28,7 +25,6 @@ pub fn fs_serial_core_with_return<E>(
 #[cfg(feature = "async")]
 pub async fn fs_async_serial_core_with_return<E>(
     name: &str,
-    _max_wait: Option<Duration>,
     path: Option<&str>,
     fut: impl std::future::Future<Output = Result<(), E>>,
 ) -> Result<(), E> {
@@ -43,7 +39,6 @@ pub async fn fs_async_serial_core_with_return<E>(
 #[cfg(feature = "async")]
 pub async fn fs_async_serial_core(
     name: &str,
-    _max_wait: Option<Duration>,
     path: Option<&str>,
     fut: impl std::future::Future<Output = ()>,
 ) {
@@ -64,14 +59,14 @@ mod tests {
 
     #[test]
     fn test_serial() {
-        fs_serial_core("test", None, None, || {});
+        fs_serial_core("test", None, || {});
     }
 
     #[test]
     fn unlock_on_assert_sync_without_return() {
         let lock_path = path_for_name("unlock_on_assert_sync_without_return");
         let _ = panic::catch_unwind(|| {
-            fs_serial_core("foo", None, Some(&lock_path), || {
+            fs_serial_core("foo", Some(&lock_path), || {
                 assert!(false);
             })
         });

--- a/serial_test/tests/tests.rs
+++ b/serial_test/tests/tests.rs
@@ -2,7 +2,7 @@ use serial_test::local_serial_core;
 
 #[test]
 fn test_empty_serial_call() {
-    local_serial_core("beta", None, || {
+    local_serial_core("beta", || {
         println!("Bar");
     });
 }

--- a/serial_test_test/src/lib.rs
+++ b/serial_test_test/src/lib.rs
@@ -107,14 +107,6 @@ mod tests {
     use serial_test::{file_parallel, file_serial};
 
     #[test]
-    #[serial(timeout_key, timeout_ms = 60000)]
-    fn demo_timeout_with_key() {}
-
-    #[test]
-    #[serial(timeout_ms = 60000)]
-    fn demo_timeout() {}
-
-    #[test]
     #[serial]
     fn test_serial_no_arg() {
         init();


### PR DESCRIPTION
As noted in #79, `timeout_ms` is quite frankly confusing, doesn't do what people expect it to (set a timeout on a function) and also doesn't reliably do what I originally wanted it to do (detect test locks and timeout).

This PR therefore removes the whole thing.