### PR TITLE
Set rust-version in test to fix clippy issue

### DIFF
--- a/serial_test_test/Cargo.toml
+++ b/serial_test_test/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 version = "1.0.0"
 authors = ["Tom Parker-Shemilt <palfrey@tevp.net>"]
 edition = "2018"
+rust-version = "1.51.0"
 
 [dependencies]
 serial_test = { path="../serial_test", default_features = false }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args was firing, but it's not relevant for our MSRV version