### PR TITLE
Upgrade proc-macro2 to fix a nightly issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,9 +384,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/serial_test_derive/Cargo.toml
+++ b/serial_test_derive/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 syn = { version="2", features=["full"] }
-proc-macro2 = "1.0"
+proc-macro2 = "1.0.60" # Because of https://github.com/dtolnay/proc-macro2/issues/356
 
 [dev-dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
Workaround for https://github.com/dtolnay/proc-macro2/issues/356. Only occurs on nightly builds and fixable in individual projects by bumping proc-macro2 versions, so I won't be doing an explicit new release just for this.