### PR TITLE
Add is_locked_serially() to check if we are in a #[serial] context

### DIFF
--- a/serial_test/src/code_lock.rs
+++ b/serial_test/src/code_lock.rs
@@ -34,6 +34,10 @@ impl UniqueReentrantMutex {
     pub fn is_locked(&self) -> bool {
         self.locks.is_locked()
     }
+
+    pub fn is_locked_by_current_thread(&self) -> bool {
+        self.locks.is_locked_by_current_thread()
+    }
 }
 
 #[inline]
@@ -42,6 +46,63 @@ pub(crate) fn global_locks() -> &'static HashMap<String, UniqueReentrantMutex> {
     let _ = env_logger::builder().try_init();
     static LOCKS: OnceCell<HashMap<String, UniqueReentrantMutex>> = OnceCell::new();
     LOCKS.get_or_init(HashMap::new)
+}
+
+/// Check if the current thread is holding a serial lock
+///
+/// Can be used to assert that a piece of code can only be called
+/// from a test marked `#[serial]`.
+///
+/// Example, with `#[serial]`:
+///
+/// ```
+/// use serial_test::{is_locked_serially, serial};
+///
+/// fn do_something_in_need_of_serialization() {
+///     assert!(is_locked_serially(None));
+///
+///     // ...
+/// }
+///
+/// #[test]
+/// # fn unused() {}
+/// #[serial]
+/// fn main() {
+///     do_something_in_need_of_serialization();
+/// }
+/// ```
+///
+/// Example, missing `#[serial]`:
+///
+/// ```should_panic
+/// use serial_test::{is_locked_serially, serial};
+///
+/// #[test]
+/// # fn unused() {}
+/// // #[serial] // <-- missing
+/// fn main() {
+///     assert!(is_locked_serially(None));
+/// }
+/// ```
+///
+/// Example, `#[test(some_key)]`:
+///
+/// ```
+/// use serial_test::{is_locked_serially, serial};
+///
+/// #[test]
+/// # fn unused() {}
+/// #[serial(some_key)]
+/// fn main() {
+///     assert!(is_locked_serially(Some("some_key")));
+///     assert!(!is_locked_serially(None));
+/// }
+/// ```
+pub fn is_locked_serially(name: Option<&str>) -> bool {
+    global_locks()
+        .get(name.unwrap_or_default())
+        .map(|lock| lock.get().is_locked_by_current_thread())
+        .unwrap_or_default()
 }
 
 static MUTEX_ID: AtomicU32 = AtomicU32::new(1);
@@ -67,4 +128,67 @@ pub(crate) fn check_new_key(name: &str) {
         Entry::Occupied(o) => o,
         Entry::Vacant(v) => v.insert_entry(UniqueReentrantMutex::new_mutex(name)),
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{local_parallel_core, local_serial_core};
+
+    const NAME1: &str = "NAME1";
+    const NAME2: &str = "NAME2";
+
+    #[test]
+    fn assert_serially_locked_without_name() {
+        local_serial_core(vec![""], None, || {
+            assert!(is_locked_serially(None));
+            assert!(!is_locked_serially(Some("no_such_name")));
+        });
+    }
+
+    #[test]
+    fn assert_serially_locked_with_multiple_names() {
+        local_serial_core(vec![NAME1, NAME2], None, || {
+            assert!(is_locked_serially(Some(NAME1)));
+            assert!(is_locked_serially(Some(NAME2)));
+            assert!(!is_locked_serially(Some("no_such_name")));
+            assert!(!is_locked_serially(None));
+        });
+    }
+
+    #[test]
+    fn assert_serially_locked_when_actually_locked_parallel() {
+        local_parallel_core(vec![NAME1, NAME2], None, || {
+            assert!(!is_locked_serially(Some(NAME1)));
+            assert!(!is_locked_serially(Some(NAME2)));
+            assert!(!is_locked_serially(Some("no_such_name")));
+            assert!(!is_locked_serially(None));
+        });
+    }
+
+    #[test]
+    fn assert_serially_locked_outside_serial_lock() {
+        assert!(!is_locked_serially(Some(NAME1)));
+        assert!(!is_locked_serially(Some(NAME2)));
+        assert!(!is_locked_serially(None));
+
+        local_serial_core(vec![NAME1], None, || {
+            // ...
+        });
+
+        assert!(!is_locked_serially(Some(NAME1)));
+        assert!(!is_locked_serially(Some(NAME2)));
+        assert!(!is_locked_serially(None));
+    }
+
+    #[test]
+    fn assert_serially_locked_in_different_thread() {
+        local_serial_core(vec![NAME1, NAME2], None, || {
+            std::thread::spawn(|| {
+                assert!(!is_locked_serially(Some(NAME2)));
+            })
+            .join()
+            .unwrap();
+        });
+    }
 }

--- a/serial_test/src/lib.rs
+++ b/serial_test/src/lib.rs
@@ -112,3 +112,5 @@ pub use serial_test_derive::{parallel, serial};
 
 #[cfg(feature = "file_locks")]
 pub use serial_test_derive::{file_parallel, file_serial};
+
+pub use code_lock::is_locked_serially;

--- a/serial_test/src/rwlock.rs
+++ b/serial_test/src/rwlock.rs
@@ -54,6 +54,10 @@ impl Locks {
         self.arc.serial.is_locked()
     }
 
+    pub fn is_locked_by_current_thread(&self) -> bool {
+        self.arc.serial.is_owned_by_current_thread()
+    }
+
     pub fn serial(&self) -> MutexGuardWrapper {
         #[cfg(feature = "logging")]
         debug!("Get serial lock '{}'", self.name);


### PR DESCRIPTION
I've recently had [this code added to rustls-tls-native](https://github.com/rustls/rustls-native-certs/pull/109):

```
/// Cargo, at least sometimes, sets SSL_CERT_FILE and SSL_CERT_DIR internally,
/// it uses OpenSSL. So, always unset both at the beginning of a test even if
/// the test doesn't use either.
///
/// # Safety
///
/// This is only safe if used together with `#[serial]` because calling
/// `[env::remove_var()]` is unsafe if another thread is running.
///
/// Note that `env::remove_var()` is scheduled to become unsafe in Rust
/// Edition 2024.
pub(crate) unsafe fn clear_env() {
    env::remove_var("SSL_CERT_FILE");
    env::remove_var("SSL_CERT_DIR");
}
```

`clear_env()` is called from various tests and it's really easy to forget `#[serial]`. This change will make it possible
to add an `assert!()` to ensure we didn't forget:

```
pub(crate) unsafe fn clear_env() {
    assert!(serial_test::is_locked_serially(None));

    env::remove_var("SSL_CERT_FILE");
    env::remove_var("SSL_CERT_DIR");
}
```