### PR TITLE
Stop using tokio in test which runs all futures sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,6 @@ dependencies = [
  "parking_lot",
  "scc",
  "serial_test_derive",
- "tokio",
 ]
 
 [[package]]

--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -25,7 +25,6 @@ env_logger = {version="0.10", optional=true}
 
 [dev-dependencies]
 itertools = "0.10"
-tokio = { version = "^1.27", features = ["macros", "rt"] }
 
 [features]
 default = ["logging", "async"]

--- a/serial_test/src/parallel_code_lock.rs
+++ b/serial_test/src/parallel_code_lock.rs
@@ -133,9 +133,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test]
     #[cfg(feature = "async")]
-    async fn unlock_on_assert_async_without_return() {
+    fn unlock_on_assert_async_without_return() {
         async fn demo_assert() {
             assert!(false);
         }
@@ -149,8 +149,6 @@ mod tests {
         }
         // as per https://stackoverflow.com/a/66529014/320546
         let _ = panic::catch_unwind(|| {
-            let handle = tokio::runtime::Handle::current();
-            let _enter_guard = handle.enter();
             futures::executor::block_on(call_serial_test_fn());
         });
         assert_eq!(
@@ -163,9 +161,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test]
     #[cfg(feature = "async")]
-    async fn unlock_on_assert_async_with_return() {
+    fn unlock_on_assert_async_with_return() {
         async fn demo_assert() -> Result<(), Error> {
             assert!(false);
             Ok(())
@@ -183,8 +181,6 @@ mod tests {
 
         // as per https://stackoverflow.com/a/66529014/320546
         let _ = panic::catch_unwind(|| {
-            let handle = tokio::runtime::Handle::current();
-            let _enter_guard = handle.enter();
             futures::executor::block_on(call_serial_test_fn());
         });
         assert_eq!(

--- a/serial_test/src/parallel_file_lock.rs
+++ b/serial_test/src/parallel_file_lock.rs
@@ -131,9 +131,9 @@ mod tests {
         unlock_ok(&lock_path);
     }
 
-    #[tokio::test]
+    #[test]
     #[cfg(feature = "async")]
-    async fn unlock_on_assert_async_without_return() {
+    fn unlock_on_assert_async_without_return() {
         let lock_path = path_for_name("unlock_on_assert_async_without_return");
         async fn demo_assert() {
             assert!(false);
@@ -147,18 +147,15 @@ mod tests {
             .await
         }
 
-        // as per https://stackoverflow.com/a/66529014/320546
         let _ = panic::catch_unwind(|| {
-            let handle = tokio::runtime::Handle::current();
-            let _enter_guard = handle.enter();
             futures::executor::block_on(call_serial_test_fn(&lock_path));
         });
         unlock_ok(&lock_path);
     }
 
-    #[tokio::test]
+    #[test]
     #[cfg(feature = "async")]
-    async fn unlock_on_assert_async_with_return() {
+    fn unlock_on_assert_async_with_return() {
         let lock_path = path_for_name("unlock_on_assert_async_with_return");
 
         async fn demo_assert() -> Result<(), Error> {
@@ -176,10 +173,7 @@ mod tests {
             .await;
         }
 
-        // as per https://stackoverflow.com/a/66529014/320546
         let _ = panic::catch_unwind(|| {
-            let handle = tokio::runtime::Handle::current();
-            let _enter_guard = handle.enter();
             futures::executor::block_on(call_serial_test_fn(&lock_path));
         });
         unlock_ok(&lock_path);


### PR DESCRIPTION
futures::executor::block_on() runs a future to completion in the current thread and there as nothing being spawned to a worker thread (e.g. tokio::spawn()).

Let's make it clear that nothing is running on the tokio runtime by removing it.

I'm not sure this is the right approach. Is there something here you explicitly want to have tested on the tokio runtime or perhaps even a different thread?