### PR TITLE
default_features -> default-features

### DIFF
--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -17,7 +17,7 @@ serial_test_derive = { version = "~3.1.1", path = "../serial_test_derive" }
 fslock = { version = "0.2", optional = true }
 document-features = { version = "0.2", optional = true }
 log = { version = ">=0.4.4", optional = true }
-futures = { version = "^0.3", default_features = false, features = [
+futures = { version = "^0.3", default-features = false, features = [
     "executor",
 ], optional = true}
 scc = { version = "2"}

--- a/serial_test_test/Cargo.toml
+++ b/serial_test_test/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 rust-version = "1.68.2"
 
 [dependencies]
-serial_test = { path="../serial_test", default_features = false }
+serial_test = { path="../serial_test", default-features = false }
 once_cell = "^1.19"
 env_logger = ">=0.6.1"
 parking_lot = "^0.12"
@@ -20,7 +20,7 @@ log = { version = ">=0.4.4" }
 [dev-dependencies]
 tokio = { version = "^1.27", features = ["macros", "rt"] }
 actix-rt = { version = "^2.8", features = ["macros"] }
-futures-util = {version = "^0.3", default_features = false }
+futures-util = {version = "^0.3", default-features = false }
 
 [features]
 default = ["serial_test/logging", "async", "serial_test/test_logging"]


### PR DESCRIPTION
Fixes https://doc.rust-lang.org/edition-guide/rust-2024/cargo-table-key-names.html before we get there, as it's backwards compatible