### PR TITLE
Stop using cargo binstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,8 @@ jobs:
         env:
           RUSTFLAGS: -Dwarnings
         continue-on-error: ${{ matrix.rust == 'nightly' || matrix.rust == 'beta' }}
-      - name: Install cargo-binstall
-        run: |
-          curl --location --remote-name https://github.com/ryankurte/cargo-binstall/releases/download/v1.12.0/cargo-binstall-x86_64-unknown-linux-musl.tgz
-          tar -zxvf cargo-binstall-x86_64-unknown-linux-musl.tgz
-          mv cargo-binstall ~/.cargo/bin
-          ls -l ~/.cargo/bin
       - name: Install "build all features"
-        run: cargo binstall cargo-all-features --no-confirm --version 1.10.0 --force
+        run: cargo install cargo-all-features --version 1.10.0 --force --locked
       - name: Build all features
         run: cargo build-all-features
       - name: Test all features


### PR DESCRIPTION
Because it's installing cargo-all-features with `cargo install` and it's breaking (https://github.com/palfrey/serial_test/actions/runs/17364198516/job/49288431074) due to using packages from newer versions and so the 1.68.2 test breaks