### PR TITLE
Add std feature to wasm-bindgen-test to avoid breaking dep updates

### DIFF
--- a/serial_test_test/Cargo.toml
+++ b/serial_test_test/Cargo.toml
@@ -13,7 +13,7 @@ once_cell = { version="^1.19", default-features = false }
 env_logger = { version=">=0.6.1", default-features = false }
 parking_lot = { version="^0.12", default-features = false }
 lock_api = { version="^0.4.7", default-features = false }
-wasm-bindgen-test = {version="^0.3.50", optional=true, default-features = false }
+wasm-bindgen-test = {version="^0.3.50", optional=true, default-features = false, features=["std"] }
 scoped-tls = { version="1", optional=true, default-features = false }
 log = { version = ">=0.4.4" , default-features = false }
 scc = { version = "2", default-features = false}


### PR DESCRIPTION
Without this, you get
```
   Compiling wasm-bindgen-test v0.3.56
error[E0152]: found duplicate lang item `panic_impl`
   --> /home/palfrey/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasm-bindgen-test-0.3.56/src/rt/mod.rs:335:9
    |
335 | /         fn panic_handler(panic_info: &core::panic::PanicInfo<'_>) -> ! {
336 | |             panic_handling(panic_info.to_string());
337 | |             unreachable!();
338 | |         }
    | |_________^
    |
    = note: the lang item is first defined in crate `std` (which `once_cell` depends on)
    = note: first definition in `std` loaded from /home/palfrey/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-210854cf1daa4bec.rlib
    = note: second definition in the local crate (`wasm_bindgen_test`)
```

This is due to https://github.com/wasm-bindgen/wasm-bindgen/pull/4812 providing the `panic_handler` to non-std configs for all architectures now, not just wasm32