### PR TITLE
specify rust-version for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["serial_test", "serial_test_derive", "serial_test_test"]
+
+[workspace.package]
+rust-version = "1.68"

--- a/serial_test/Cargo.toml
+++ b/serial_test/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 version = "3.3.1"
 authors = ["Tom Parker-Shemilt <palfrey@tevp.net>"]
 edition = "2018"
+rust-version.workspace = true
 repository = "https://github.com/palfrey/serial_test/"
 readme = "README.md"
 categories = ["development-tools::testing"]

--- a/serial_test_derive/Cargo.toml
+++ b/serial_test_derive/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 version = "3.3.1"
 authors = ["Tom Parker-Shemilt <palfrey@tevp.net>"]
 edition = "2018"
+rust-version.workspace = true
 readme = "README.md"
 repository = "https://github.com/palfrey/serial_test/"
 categories = ["development-tools::testing"]

--- a/serial_test_test/Cargo.toml
+++ b/serial_test_test/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 version = "3.3.1"
 authors = ["Tom Parker-Shemilt <palfrey@tevp.net>"]
 edition = "2018"
-rust-version = "1.68.2"
+rust-version.workspace = true
 
 [dependencies]
 serial_test = { path="../serial_test", default-features = false }


### PR DESCRIPTION
MSRV doesn't currently appear in crates.io metadata, this should fix it