### PR TITLE
Upgrade cargo-all-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
           RUSTFLAGS: -Dwarnings
         continue-on-error: ${{ matrix.rust == 'nightly' || matrix.rust == 'beta' }}
       - name: Install "build all features" 1.12
-        run: cargo install cargo-all-features --version 1.12.0 --force
+        run: cargo install cargo-all-features --version 1.12.0 --force --locked
         if: ${{ matrix.rust != '1.68.0' }}
       - name: Install "build all features" 1.10
-        run: cargo install cargo-all-features --version 1.10.0 --force
+        run: cargo install cargo-all-features --version 1.10.0 --force --locked
         if: ${{ matrix.rust == '1.68.0' }}        
       - name: Build all features
         run: cargo build-all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           RUSTFLAGS: -Dwarnings
         continue-on-error: ${{ matrix.rust == 'nightly' || matrix.rust == 'beta' }}
       - name: Install "build all features"
-        run: cargo install cargo-all-features --version 1.10.0 --force --locked
+        run: cargo install cargo-all-features --version 1.12.0 --force --locked
       - name: Build all features
         run: cargo build-all-features
       - name: Test all features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,12 @@ jobs:
         env:
           RUSTFLAGS: -Dwarnings
         continue-on-error: ${{ matrix.rust == 'nightly' || matrix.rust == 'beta' }}
-      - name: Install "build all features"
-        run: cargo install cargo-all-features --version 1.12.0 --force --locked
+      - name: Install "build all features" 1.12
+        run: cargo install cargo-all-features --version 1.12.0 --force
+        if: ${{ matrix.rust != '1.68.0' }}
+      - name: Install "build all features" 1.10
+        run: cargo install cargo-all-features --version 1.10.0 --force
+        if: ${{ matrix.rust == '1.68.0' }}        
       - name: Build all features
         run: cargo build-all-features
       - name: Test all features


### PR DESCRIPTION
Because the previous version hit
```
error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.38.4/src/backend/linux_raw/io/errno.rs:28:25
   |
28 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
   | 
```